### PR TITLE
hmPlot named incorrectly

### DIFF
--- a/clickstream_analysis.R
+++ b/clickstream_analysis.R
@@ -17,7 +17,7 @@ summary(mc)
 
 ##plot transition diagram and heatmap
 plot(mc)
-hmplot(mc)
+hmPlot(mc)
 
 ##clustering
 set.seed(42)


### PR DESCRIPTION
Looks like the function `hmplot` is in fact `hmPlot` in the library. See page 17 in this [R lib doc](https://cran.r-project.org/web/packages/clickstream/clickstream.pdf).
Thanks for a great article and including this code. I'm really new to all this and it made it really easy to get started.